### PR TITLE
Rework CloPos and add tests

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunklike/CloPos.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/world/level/chunklike/CloPos.java
@@ -17,7 +17,13 @@ import net.minecraft.world.level.ChunkPos;
  * When packed as a long, chunk positions are encoded the same as {@link ChunkPos#toLong}; cube positions are packed with 21 bits per axis. The parity of the top two bits of the long is
  * used to distinguish between chunks and cubes (if bit 0 XOR bit 1, it is a cube, otherwise it is a chunk).
  * <br>
- * Also note that the top two bits (the parity bit, and the top bit of the Z coordinate) are inverted, as otherwise {@link Long#MAX_VALUE} would be a valid position (-1, -1, -1).
+ * Also note that for cubes the top two bits (the parity bit, and the top bit of the Z coordinate) are inverted, as otherwise {@link Long#MAX_VALUE} would be a valid position (-1, -1, -1).
+ * <br>
+ * Invalid CloPos long:          <br> <code> 0b01111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111 </code> <br>
+ * Positive Z cube CloPos long:  <br> <code> 0b01ZZZZZZ ZZZZZZZZ ZZZZZZYY YYYYYYYY YYYYYYYY YYYXXXXX XXXXXXXX XXXXXXXX </code> <br>
+ * Negative Z cube CloPos long:  <br> <code> 0b10ZZZZZZ ZZZZZZZZ ZZZZZZYY YYYYYYYY YYYYYYYY YYYXXXXX XXXXXXXX XXXXXXXX </code> <br>
+ * Positive Z chunk CloPos long: <br> <code> 0b00ZZZZZZ ZZZZZZZZ ZZZZZZZZ ZZZZZZZZ XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX </code> <br>
+ * Negative Z chunk CloPos long: <br> <code> 0b11ZZZZZZ ZZZZZZZZ ZZZZZZZZ ZZZZZZZZ XXXXXXXX XXXXXXXX XXXXXXXX XXXXXXXX </code>
  */
 public class CloPos {
     private static final int CLO_Y_COLUMN_INDICATOR = Integer.MAX_VALUE;
@@ -132,17 +138,9 @@ public class CloPos {
 
     public long asLong() {
         if (isCube()) {
-            long i = 0L;
-            i |= ((long) this.x & (1 << 21) - 1);
-            i |= ((long) this.y & (1 << 21) - 1) << 21;
-            i |= ((long) this.z & (1 << 21) - 1) << 42;
-            // If 2nd bit isn't set, set 1st bit, since cubes are marked by starting with 0b01 or 0b10
-            if (i < (1L << 62)) i |= (1L << 63);
-            // invert the top two bits for storage
-            i ^= TOP_TWO_BITS_MASK;
-            return i;
+            return CloPos.asLong(x, y, z);
         } else {
-            return ChunkPos.asLong(this.x, this.z);
+            return CloPos.asLong(x, z);
         }
     }
 

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/test/server/level/TestCubicChunkTracker.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/test/server/level/TestCubicChunkTracker.java
@@ -18,8 +18,6 @@ import it.unimi.dsi.fastutil.longs.Long2ByteOpenHashMap;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.server.level.ChunkTracker;
-import net.minecraft.server.level.TickingTracker;
-import net.minecraft.world.level.ChunkPos;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -128,7 +126,7 @@ public class TestCubicChunkTracker {
         }
         for (int i = 0; i < 100; i++) {
             var testPos = CloPos.cube(rand.nextInt(0, 20) - 10, 0, rand.nextInt(0, 20) - 10);
-            var testCol = testPos.correspondingColumnCloPos(rand.nextInt(0, CubicConstants.DIAMETER_IN_SECTIONS), rand.nextInt(0, CubicConstants.DIAMETER_IN_SECTIONS));
+            var testCol = testPos.correspondingChunkCloPos(rand.nextInt(0, CubicConstants.DIAMETER_IN_SECTIONS), rand.nextInt(0, CubicConstants.DIAMETER_IN_SECTIONS));
             // Minimum distance from all sources should be the level
             var dist = Integer.MAX_VALUE;
             for (int j = 0; j < srcPosClo.size(); j++) {
@@ -142,7 +140,7 @@ public class TestCubicChunkTracker {
         for (int i = 0; i < srcPosClo.size(); i++) {
             for (int dx = 0; dx < CubicConstants.DIAMETER_IN_SECTIONS; dx++) {
                 for (int dz = 0; dz < CubicConstants.DIAMETER_IN_SECTIONS; dz++) {
-                    var srcChunk = srcPosClo.get(i).correspondingColumnCloPos(dx, dz);
+                    var srcChunk = srcPosClo.get(i).correspondingChunkCloPos(dx, dz);
                     assertEquals(0, tracker.getLevel(srcChunk.asLong()), "Level should be zero at chunks intersecting source cube.");
                 }
             }
@@ -230,14 +228,14 @@ public class TestCubicChunkTracker {
     @Test public void testSingleChunkSource() {
         var tracker = new TestCubicTracker(8, 16, 256);
         ((MarkableAsCubic) tracker).cc_setCubic();
-        var srcPos = CloPos.column(-4, 3);
+        var srcPos = CloPos.chunk(-4, 3);
         tracker.addSource(srcPos.asLong(), 0);
         tracker.runAllUpdates();
         var rand = new Random(333);
         assertEquals(0, tracker.getLevel(srcPos.asLong()), "Level should be zero at source chunk.");
-        assertThat(tracker.chunks.keySet()).withFailMessage("No cubes should be loaded by columns.").allSatisfy(CloPos::isColumn);
+        assertThat(tracker.chunks.keySet()).withFailMessage("No cubes should be loaded by columns.").allSatisfy(CloPos::isChunk);
         for (int i = 0; i < 1000; i++) {
-            var testPos = CloPos.column(srcPos.getX() + rand.nextInt(0, 20) - 10, srcPos.getZ() + rand.nextInt(0, 20) - 10);
+            var testPos = CloPos.chunk(srcPos.getX() + rand.nextInt(0, 20) - 10, srcPos.getZ() + rand.nextInt(0, 20) - 10);
             var dist = Misc.chebyshevDistance(srcPos.chunkPos(), testPos.chunkPos());
             assertEquals(Math.min(7, dist), tracker.getLevel(testPos.asLong()), String.format("Level at chunk %d %d.", testPos.getX(), testPos.getZ()));
         }
@@ -249,7 +247,7 @@ public class TestCubicChunkTracker {
     private void addAndTestVanillaChunkSources(List<CloPos> srcPosClo, TestCubicTracker tracker, Random rand, int numSourcesAdded) {
         if (numSourcesAdded == 0) {
             for (int i = 0; i < numSourcesAdded; i++) {
-                srcPosClo.add(CloPos.column(rand.nextInt(0, 20)-10, rand.nextInt(0, 20)-10));
+                srcPosClo.add(CloPos.chunk(rand.nextInt(0, 20)-10, rand.nextInt(0, 20)-10));
                 tracker.addSource(srcPosClo.get(srcPosClo.size() - 1).toLong(), 0);
             }
             tracker.runAllUpdates();
@@ -280,7 +278,7 @@ public class TestCubicChunkTracker {
 
     private void testVanillaChunkSourcePropagation(List<CloPos> srcPosClo, TestCubicTracker tracker, Random rand) {
         for (int i = 0; i < 1000; i++) {
-            var testPos = CloPos.column(rand.nextInt(0, 20) - 10, rand.nextInt(0, 20) - 10).chunkPos();
+            var testPos = CloPos.chunk(rand.nextInt(0, 20) - 10, rand.nextInt(0, 20) - 10).chunkPos();
             var dist = Integer.MAX_VALUE;
             for (int j = 0; j < srcPosClo.size(); j++) {
                 dist = Math.min(dist, Misc.chebyshevDistance(srcPosClo.get(j).chunkPos(), testPos));

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/test/server/level/TestCubicDistanceManager.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/test/server/level/TestCubicDistanceManager.java
@@ -273,18 +273,18 @@ public class TestCubicDistanceManager {
     @Test public void testShouldForceTicksVanilla() {
         var distanceManager = setupDistanceManager();
         distanceManager.addRegionTicket(TicketType.START, new ChunkPos(0, 0), 0,  Unit.INSTANCE, true);
-        assertTrue(distanceManager.shouldForceTicks(0));
+        assertTrue(distanceManager.shouldForceTicks(ChunkPos.asLong(0, 0)));
         distanceManager.removeRegionTicket(TicketType.START, new ChunkPos(0, 0), 0,  Unit.INSTANCE, true);
-        assertFalse(distanceManager.shouldForceTicks(0));
+        assertFalse(distanceManager.shouldForceTicks(ChunkPos.asLong(0, 0)));
     }
 
     @Test public void testShouldForceTicks() {
         var distanceManager = setupDistanceManager();
         ((MarkableAsCubic) distanceManager).cc_setCubic();
         ((CubicDistanceManager)distanceManager).addRegionTicket(CubicTicketType.START, CloPos.cube(0, 0, 0), 0,  Unit.INSTANCE, true);
-        assertTrue(distanceManager.shouldForceTicks(0));
+        assertTrue(distanceManager.shouldForceTicks(CloPos.asLong(0, 0, 0)));
         ((CubicDistanceManager)distanceManager).removeRegionTicket(CubicTicketType.START, CloPos.cube(0, 0, 0), 0,  Unit.INSTANCE, true);
-        assertFalse(distanceManager.shouldForceTicks(0));
+        assertFalse(distanceManager.shouldForceTicks(CloPos.asLong(0, 0, 0)));
     }
 
     // Tests for PlayerTicketTracker

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/test/world/level/chunklike/TestCloPos.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/test/world/level/chunklike/TestCloPos.java
@@ -1,38 +1,207 @@
 package io.github.opencubicchunks.cubicchunks.test.world.level.chunklike;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Random;
+
+import io.github.opencubicchunks.cc_core.api.CubePos;
 import io.github.opencubicchunks.cc_core.api.CubicConstants;
+import io.github.opencubicchunks.cc_core.utils.Coords;
 import io.github.opencubicchunks.cubicchunks.world.level.chunklike.CloPos;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.world.level.ChunkPos;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestCloPos {
-    // TODO proper tests
-    @Test public void testRawCoords() {
-        var pos = CloPos.cube(3, 4, 5).asLong();
-        pos = CloPos.setRawX(pos, -77);
-        pos = CloPos.setRawY(pos, 543);
-        pos = CloPos.setRawZ(pos, -1743);
-        assertEquals(-77, CloPos.extractRawX(pos));
-        assertEquals(543, CloPos.extractRawY(pos));
-        assertEquals(-1743, CloPos.extractRawZ(pos));
+    // If using 16x16x16 cubes, we don't have enough bits to fit all coordinates from -30 million to 30 million.
+    static int maxValidDistance = CubicConstants.DIAMETER_IN_SECTIONS == 1 ? 15001000 : 30001000;
+    static int maxValidDistanceCube = maxValidDistance / CubicConstants.DIAMETER_IN_BLOCKS;
 
+    private void constructionAndBasicMethods(int x, int y, int z) {
+        var cube = CloPos.cube(x, y, z);
+        assertEquals(x, cube.getX());
+        assertEquals(y, cube.getY());
+        assertEquals(z, cube.getZ());
+        assertTrue(cube.isCube());
+        assertFalse(cube.isChunk());
+        assertThrows(UnsupportedOperationException.class, cube::chunkPos);
+
+        var cube2 = CloPos.cube(CubePos.of(x, y, z));
+
+        assertEquals(cube, cube2);
+
+        assertEquals(CubePos.from(new BlockPos(x, y, z)), CloPos.cube(new BlockPos(x, y, z)).cubePos());
+
+        var sectionPos = SectionPos.of(x, y, z);
+        assertEquals(CubePos.from(sectionPos), CloPos.section(sectionPos).cubePos());
+
+        var column = CloPos.chunk(x, z);
+        assertEquals(x, column.getX());
+        assertEquals(z, column.getZ());
+        assertTrue(column.isChunk());
+        assertFalse(column.isCube());
+        assertThrows(UnsupportedOperationException.class, column::cubePos);
+        assertThrows(UnsupportedOperationException.class, column::getY);
+
+        var column2 = CloPos.chunk(new ChunkPos(x, z));
+
+        assertEquals(column, column2);
+        assertEquals(new ChunkPos(x, z), column.chunkPos());
+
+        assertEquals(cube, CloPos.fromLong(cube.asLong()));
+        assertEquals(column, CloPos.fromLong(column.asLong()));
+
+        assertEquals(cube.asLong(), CloPos.asLong(x, y, z));
+        assertEquals(column.asLong(), CloPos.asLong(x, z));
     }
 
-    @Test public void testChunks() {
-        for (int x = -8; x <= 8; x++) {
-            for (int z = -8; z <= 8; z++) {
-                var pos = CloPos.column(x, z);
-                assertTrue(pos.isColumn());
-                assertTrue(CloPos.isColumn(pos.asLong()));
-            }
+    private void packedUnpackedParity(int x, int y, int z) {
+        var cube = CloPos.cube(x, y, z);
+        var cubeLong = CloPos.asLong(x, y, z);
+
+        assertEquals(cube.getX(), CloPos.extractX(cubeLong));
+        assertEquals(cube.getY(), CloPos.extractY(cubeLong));
+        assertEquals(cube.getZ(), CloPos.extractZ(cubeLong));
+        assertTrue(CloPos.isCube(cubeLong));
+        assertFalse(CloPos.isChunk(cubeLong));
+        var neighbors1 = new ArrayList<>();
+        var neighbors2 = new ArrayList<>();
+        cube.forEachNeighbor(neighbors1::add);
+        CloPos.forEachNeighbor(cubeLong, (val) -> neighbors2.add(CloPos.fromLong(val)));
+        assertEquals(neighbors1, neighbors2);
+
+        var column = CloPos.chunk(x, z);
+        var columnLong = CloPos.asLong(x, z);
+        assertEquals(column.getX(), CloPos.extractX(columnLong));
+        assertThrows(IllegalArgumentException.class, () -> CloPos.extractY(columnLong));
+        assertEquals(column.getZ(), CloPos.extractZ(columnLong));
+        assertTrue(CloPos.isChunk(columnLong));
+        assertFalse(CloPos.isCube(columnLong));
+        neighbors1.clear();
+        neighbors2.clear();
+        column.forEachNeighbor(neighbors1::add);
+        CloPos.forEachNeighbor(columnLong, (val) -> neighbors2.add(CloPos.fromLong(val)));
+        assertEquals(neighbors1, neighbors2);
+    }
+
+    // offsetX/Z should be between 0 and CubicConstants.DIAMETER_IN_SECTIONS
+    private void correspondingPositions(int x, int y, int z, int offsetX, int offsetY, int offsetZ) {
+        // Calling methods with cube pos
+        var cube = CloPos.cube(x, y, z);
+        var verticallyOffsetCube = CloPos.cube(x, y+offsetY, z);
+        assertEquals(cube, cube.correspondingCubeCloPos(y));
+        assertEquals(cube.cubePos(), cube.correspondingCubePos(y));
+        assertEquals(verticallyOffsetCube, cube.correspondingCubeCloPos(y+offsetY));
+        assertEquals(verticallyOffsetCube.cubePos(), cube.correspondingCubePos(y+offsetY));
+        var expectedChunkPosZeroOffset = CloPos.chunk(Coords.cubeToSection(x, 0), Coords.cubeToSection(z, 0));
+        assertEquals(expectedChunkPosZeroOffset, cube.correspondingChunkCloPos());
+        assertEquals(expectedChunkPosZeroOffset.chunkPos(), cube.correspondingChunkPos());
+        var expectedChunkPos = CloPos.chunk(Coords.cubeToSection(x, offsetX), Coords.cubeToSection(z, offsetZ));
+        assertEquals(expectedChunkPos, cube.correspondingChunkCloPos(offsetX, offsetZ));
+        assertEquals(expectedChunkPos.chunkPos(), cube.correspondingChunkPos(offsetX, offsetZ));
+        // Calling methods with chunk pos
+        var chunk = CloPos.chunk(x, z);
+        assertEquals(chunk, chunk.correspondingChunkCloPos());
+        assertEquals(chunk, chunk.correspondingChunkCloPos(offsetX, offsetZ));
+        assertEquals(chunk.chunkPos(), chunk.correspondingChunkPos());
+        assertEquals(chunk.chunkPos(), chunk.correspondingChunkPos(offsetX, offsetZ));
+        var correspondingCube = CloPos.cube(Coords.sectionToCube(x), y, Coords.sectionToCube(z));
+        assertEquals(correspondingCube, chunk.correspondingCubeCloPos(y));
+        assertEquals(correspondingCube.cubePos(), chunk.correspondingCubePos(y));
+    }
+
+    private void longGetSet(int x, int y, int z, int offsetX, int offsetY, int offsetZ) {
+        // Calling methods with cube pos
+        var cube = CloPos.asLong(x, y, z);
+        assertEquals(x+offsetX, CloPos.extractX(CloPos.setX(cube, x+offsetX)));
+        assertEquals(y+offsetY, CloPos.extractY(CloPos.setY(cube, y+offsetY)));
+        assertEquals(z+offsetZ, CloPos.extractZ(CloPos.setZ(cube, z+offsetZ)));
+        assertEquals(CloPos.asLong(x+offsetX, y+offsetY, z+offsetZ), CloPos.setZ(CloPos.setY(CloPos.setX(cube, x+offsetX), y+offsetY), z+offsetZ));
+        // Calling methods with chunk pos
+        var chunk = CloPos.asLong(x, z);
+        assertEquals(x+offsetX, CloPos.extractX(CloPos.setX(chunk, x+offsetX)));
+        assertThrows(IllegalArgumentException.class, () -> CloPos.setY(chunk, y+offsetY));
+        assertThrows(IllegalArgumentException.class, () -> CloPos.extractY(chunk));
+        assertEquals(z+offsetZ, CloPos.extractZ(CloPos.setZ(chunk, z+offsetZ)));
+        assertEquals(CloPos.asLong(x+offsetX, z+offsetZ), CloPos.setZ(CloPos.setX(chunk, x+offsetX), z+offsetZ));
+    }
+
+    @Test public void testConstructionAndBasicMethods() {
+        var random = new Random(7777);
+        for (int i = 0; i < 1000; i++) {
+            int x = random.nextInt(10000)-5000;
+            int y = random.nextInt(10000)-5000;
+            int z = random.nextInt(10000)-5000;
+
+            constructionAndBasicMethods(x, y, z);
         }
     }
 
-    @Test public void forEachNeighbor() {
+    @Test public void testPackedUnpackedParity() {
+        var random = new Random(7778);
+        for (int i = 0; i < 1000; i++) {
+            int x = random.nextInt(10000) - 5000;
+            int y = random.nextInt(10000) - 5000;
+            int z = random.nextInt(10000) - 5000;
+
+            packedUnpackedParity(x, y, z);
+        }
+    }
+
+    @Test public void testCorrespondingPositions() {
+        var random = new Random(7780);
+        for (int i = 0; i < 1000; i++) {
+            int x = random.nextInt(10000) - 5000;
+            int y = random.nextInt(10000) - 5000;
+            int z = random.nextInt(10000) - 5000;
+            int offsetX = random.nextInt(CubicConstants.DIAMETER_IN_SECTIONS);
+            int offsetZ = random.nextInt(CubicConstants.DIAMETER_IN_SECTIONS);
+            int offsetY = random.nextInt(10000) - 5000;
+            correspondingPositions(x, y, z, offsetX, offsetY, offsetZ);
+        }
+    }
+
+    @Test public void testLongGetSet() {
+        var random = new Random(7781);
+        for (int i = 0; i < 1000; i++) {
+            int x = random.nextInt(10000) - 5000;
+            int y = random.nextInt(10000) - 5000;
+            int z = random.nextInt(10000) - 5000;
+            int offsetX = random.nextInt(10000) - 5000;
+            int offsetZ = random.nextInt(10000) - 5000;
+            int offsetY = random.nextInt(10000) - 5000;
+            longGetSet(x, y, z, offsetX, offsetY, offsetZ);
+        }
+    }
+
+    @Test public void testHighMagnitudeCoordinates() {
+        var random = new Random(7779);
+        for (int i = 0; i < 1000; i++) {
+            // on each axis we pick either a coordinate near the magnitude limit (either positive or negative), or zero
+            int x = (maxValidDistanceCube - random.nextInt(10000)) * (random.nextInt(3) - 1);
+            int y = (maxValidDistanceCube - random.nextInt(10000)) * (random.nextInt(3) - 1);
+            int z = (maxValidDistanceCube - random.nextInt(10000)) * (random.nextInt(3) - 1);
+            int offsetSectionX = random.nextInt(CubicConstants.DIAMETER_IN_SECTIONS);
+            int offsetSectionZ = random.nextInt(CubicConstants.DIAMETER_IN_SECTIONS);
+            int offsetX = random.nextInt(10000) - 5000;
+            int offsetZ = random.nextInt(10000) - 5000;
+            int offsetY = random.nextInt(10000) - 5000;
+
+            constructionAndBasicMethods(x, y, z);
+            packedUnpackedParity(x, y, z);
+            correspondingPositions(x, y, z, offsetSectionX, offsetY, offsetSectionZ);
+            longGetSet(x, y, z, offsetX, offsetY, offsetZ);
+        }
+    }
+
+    @Test public void forEachNeighborCounts() {
         var pos = CloPos.cube(3, 4, 5);
         var cubesCols = new int[] { 0,  0 };
         pos.forEachNeighbor(p -> cubesCols[p.isCube() ? 0 : 1]++);
@@ -43,5 +212,23 @@ public class TestCloPos {
         CloPos.forEachNeighbor(pos.asLong(), p -> cubesCols[CloPos.isCube(p) ? 0 : 1]++);
         assertEquals(26, cubesCols[0]);
         assertEquals(CubicConstants.CHUNK_COUNT, cubesCols[1]);
+    }
+
+    @Test public void testLongMaxValueIsOutOfBounds() {
+        var pos = CloPos.fromLong(Long.MAX_VALUE);
+        if (pos.isCube()) {
+            assertTrue(Math.max(
+                Math.max(
+                    Math.abs(pos.getX()*CubicConstants.DIAMETER_IN_BLOCKS),
+                    Math.abs(pos.getY()*CubicConstants.DIAMETER_IN_BLOCKS)
+                ),
+                Math.abs(pos.getZ()*CubicConstants.DIAMETER_IN_BLOCKS)
+            ) > maxValidDistance, "Long.MAX_VALUE should represent an out-of-bounds CloPos, since it is used to represent invalid CloPoses, but it represents " + pos);
+        } else {
+            assertTrue(Math.max(
+                Math.abs(pos.getX())*16,
+                Math.abs(pos.getZ())*16
+            ) > maxValidDistance, "Long.MAX_VALUE should represent an out-of-bounds CloPos, since it is used to represent invalid CloPoses, but it represents " + pos);
+        }
     }
 }


### PR DESCRIPTION
This PR replaces the long packing of `CloPos` in such a way that chunk positions pack the same way as when using `ChunkPos.toLong`, for compatibility reasons.