### PR TITLE
Separate long-running tests into a separate task

### DIFF
--- a/.github/workflows/gradleBuild.yml
+++ b/.github/workflows/gradleBuild.yml
@@ -26,7 +26,9 @@ jobs:
         with:
           java-version: 17
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -x test
+      - name: Run tests
+        run: ./gradlew check
       - uses: actions/upload-artifact@v2
         with:
           name: Compiled jars

--- a/.github/workflows/gradleBuildPR.yml
+++ b/.github/workflows/gradleBuildPR.yml
@@ -23,4 +23,6 @@ jobs:
         with:
           java-version: 17
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -x test
+      - name: Run tests
+        run: ./gradlew check

--- a/build.gradle
+++ b/build.gradle
@@ -257,15 +257,6 @@ dependencies {
     testImplementation("org.hamcrest:hamcrest:2.2")
 }
 
-test {
-    useJUnitPlatform()
-    testLogging {
-        events "passed", "skipped", "failed"
-    }
-    jvmArgs("-ea", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true", "-Dmixin.checks.interfaces=true")
-    exclude "**/mixin*"
-}
-
 tasks.withType(ProcessResources).configureEach {
     var replaceProperties = [
             minecraft_version   : minecraft_version, minecraft_version_range: minecraft_version_range,
@@ -313,7 +304,9 @@ test {
     maxHeapSize = "2048M"
 
     dependsOn(project.tasks.named("unzipTests"))
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags "longRunTest"
+    }
 
     // Always run tests, even when nothing changed.
     dependsOn("cleanTest")
@@ -322,6 +315,33 @@ test {
     testLogging {
         events("passed", "skipped", "failed")
     }
+
+    jvmArgs("-ea", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true", "-Dmixin.checks.interfaces=true")
+    exclude "**/mixin*"
+}
+
+def longRunTest = tasks.register("longRunTest", Test) {
+    minHeapSize = "512M"
+    maxHeapSize = "2048M"
+
+    useJUnitPlatform {
+        includeTags "longRunTest"
+    }
+
+    // Show test results.
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+
+    jvmArgs("-ea", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true", "-Dmixin.checks.interfaces=true")
+    exclude "**/mixin*"
+
+    group = "Verification"
+    shouldRunAfter test
+}
+
+tasks.named("check") {
+    dependsOn longRunTest
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -337,7 +337,8 @@ def longRunTest = tasks.register("longRunTest", Test) {
     exclude "**/mixin*"
 
     group = "Verification"
-    shouldRunAfter test
+    mustRunAfter project.tasks.named("unzipTests")
+    shouldRunAfter project.tasks.named("test")
 }
 
 tasks.named("check") {

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/integrationtest/server/level/IntegrationTestCubicChunkMap.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/integrationtest/server/level/IntegrationTestCubicChunkMap.java
@@ -17,11 +17,11 @@ import io.github.opencubicchunks.cc_core.utils.Coords;
 import io.github.opencubicchunks.cubicchunks.mixin.test.common.server.level.ChunkHolderTestAccess;
 import io.github.opencubicchunks.cubicchunks.mixin.test.common.server.level.ChunkMapTestAccess;
 import io.github.opencubicchunks.cubicchunks.mixin.test.common.server.level.ServerChunkCacheTestAccess;
+import io.github.opencubicchunks.cubicchunks.test.LongRunTest;
 import io.github.opencubicchunks.cubicchunks.testutils.BaseTest;
 import io.github.opencubicchunks.cubicchunks.testutils.CloseableReference;
 import io.github.opencubicchunks.cubicchunks.world.level.chunklike.CloPos;
 import io.github.opencubicchunks.cubicchunks.world.level.cube.LevelCube;
-import net.minecraft.Util;
 import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ChunkLevel;
 import net.minecraft.server.level.ChunkMap;
@@ -251,6 +251,7 @@ public class IntegrationTestCubicChunkMap extends BaseTest {
     /**
      * Load a single cube at full status
      */
+    @LongRunTest
     @Test public void singleFullCube() throws Exception {
         try(var serverChunkCacheRef = createServerChunkCache()) {
             var serverChunkCache = serverChunkCacheRef.value();

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/test/LongRunTest.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/test/LongRunTest.java
@@ -1,0 +1,16 @@
+package io.github.opencubicchunks.cubicchunks.test;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Tag("longRunTest")
+public @interface LongRunTest {
+}

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/test/package-info.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/test/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package io.github.opencubicchunks.cubicchunks.test;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.github.opencubicchunks.cc_core.annotation.MethodsReturnNonnullByDefault;


### PR DESCRIPTION
`check` depends on `test` and also `longRunTest`, and `check` now runs in CI
