### PR TITLE
Update workflows to always upload test report even on catastrophic failure

### DIFF
--- a/.github/workflows/gradleBuild.yml
+++ b/.github/workflows/gradleBuild.yml
@@ -32,12 +32,12 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Compiled jars
+          name: compiled-jars
           path: build/libs/*.jar
 
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Test reports
+          name: test-reports
           path: build/reports/

--- a/.github/workflows/gradleBuild.yml
+++ b/.github/workflows/gradleBuild.yml
@@ -3,8 +3,7 @@ name: Java CI
 on:
   push:
     branches:
-      - 'MC_1.17'
-      - 'MC_1.18'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
@@ -25,11 +24,20 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
+
       - name: Build with Gradle
         run: ./gradlew build -x test
       - name: Run tests
         run: ./gradlew check
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@v4
         with:
           name: Compiled jars
-          path: build/libs/*
+          path: build/libs/*.jar
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test reports
+          path: build/reports/

--- a/.github/workflows/gradleBuildPR.yml
+++ b/.github/workflows/gradleBuildPR.yml
@@ -22,7 +22,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
+
       - name: Build with Gradle
         run: ./gradlew build -x test
       - name: Run tests
         run: ./gradlew check
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test reports
+          path: build/reports/

--- a/.github/workflows/gradleBuildPR.yml
+++ b/.github/workflows/gradleBuildPR.yml
@@ -32,5 +32,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Test reports
+          name: test-reports
           path: build/reports/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import io.github.opencubicchunks.gradle.GeneratePackageInfo
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 buildscript {
     dependencies {
@@ -328,7 +329,10 @@ def longRunTest = tasks.register("longRunTest", Test) {
 
     // Show test results.
     testLogging {
-        events("passed", "skipped", "failed")
+        events("started", "passed", "skipped", "failed")
+        showStandardStreams = true
+        exceptionFormat = TestExceptionFormat.FULL
+        minGranularity = 3
     }
 
     jvmArgs("-ea", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true", "-Dmixin.checks.interfaces=true")


### PR DESCRIPTION
I'm not actually 100% sure this will work, gh actions is still a mystery to me.

stack overflow [suggests this will work though](https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f)