### PR TITLE
Enable parallel test running

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,10 +247,10 @@ dependencies {
     // NeoForge does not yet support JUnit tests, so we use fabric loader for this instead.
     testImplementation("net.fabricmc:fabric-loader-junit:0.15.3") // required for bootstrapping in unit tests
     testImplementation("org.assertj:assertj-core:3.25.1")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testImplementation("org.mockito:mockito-core:5.2.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 
     testImplementation("org.hamcrest:hamcrest-junit:2.0.0.0")
     testImplementation("org.hamcrest:hamcrest:2.2")

--- a/build.gradle
+++ b/build.gradle
@@ -301,6 +301,12 @@ tasks.register('unzipTests', Copy) {
     into(sourceSets.test.output.classesDirs.asPath)
 }
 
+tasks.withType(Test).configureEach {
+    // gradle docs suggest processors/2 which actually runs fractionally faster than just processors
+    // forking a jvm is expensive.
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
 test {
     minHeapSize = "512M"
     maxHeapSize = "2048M"
@@ -325,6 +331,7 @@ test {
 def longRunTest = tasks.register("longRunTest", Test) {
     minHeapSize = "512M"
     maxHeapSize = "2048M"
+    systemProperty("junit.jupiter.testclass.order.default", "org.junit.jupiter.api.ClassOrderer.OrderAnnotation")
 
     useJUnitPlatform {
         includeTags "longRunTest"


### PR DESCRIPTION
This is safe because each worker is a fork of the jvm process and not a thread within a single jvm.

We have to do this as mockito is not thread safe.