### PR TITLE
Handle packets on main thread

### DIFF
--- a/src/main/java/io/github/opencubicchunks/cubicchunks/network/CCClientboundLevelChunkPacket.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/network/CCClientboundLevelChunkPacket.java
@@ -5,6 +5,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.network.handling.IPlayPayloadHandler;
 import net.neoforged.neoforge.network.handling.PlayPayloadContext;
 
@@ -30,20 +31,16 @@ public class CCClientboundLevelChunkPacket implements CustomPacketPayload {
         return ID;
     }
 
-    public static class Handler implements IPlayPayloadHandler<CCClientboundLevelChunkPacket>, FriendlyByteBuf.Reader<CCClientboundLevelChunkPacket> {
-
-        @Override public CCClientboundLevelChunkPacket apply(FriendlyByteBuf friendlyByteBuf) {
-            int x = friendlyByteBuf.readInt();
-            int z = friendlyByteBuf.readInt();
-            return new CCClientboundLevelChunkPacket(new ChunkPos(x, z));
-        }
-
+    public static class Handler implements IPlayPayloadHandler<CCClientboundLevelChunkPacket> {
         @Override public void handle(CCClientboundLevelChunkPacket payload, PlayPayloadContext context) {
             int x = payload.pos.x;
             int z = payload.pos.z;
-            ChunkPos chunkPos = new ChunkPos(x, z);
-
             // TODO P2 :: This will contain heightmap data and some other stuff
+            context.workHandler().execute(() -> updateLevelChunk(context.level().get(), x, z));
+        }
+
+        private void updateLevelChunk(Level level, int x, int z) {
+
         }
     }
 }

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/network/CCClientboundLevelCubeWithLightPacket.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/network/CCClientboundLevelCubeWithLightPacket.java
@@ -46,19 +46,13 @@ public class CCClientboundLevelCubeWithLightPacket implements CustomPacketPayloa
         return chunkData;
     }
 
-    public static class Handler implements IPlayPayloadHandler<CCClientboundLevelCubeWithLightPacket>, FriendlyByteBuf.Reader<CCClientboundLevelCubeWithLightPacket> {
+    public static class Handler implements IPlayPayloadHandler<CCClientboundLevelCubeWithLightPacket> {
         @Override
         public void handle(CCClientboundLevelCubeWithLightPacket payload, PlayPayloadContext context) {
             int x = payload.pos.getX();
             int y = payload.pos.getY();
             int z = payload.pos.getZ();
-            this.updateLevelCube(context.level().get(), x, y, z, payload);
-        }
-
-        @Override
-        public CCClientboundLevelCubeWithLightPacket apply(FriendlyByteBuf friendlyByteBuf)
-        {
-            return new CCClientboundLevelCubeWithLightPacket(friendlyByteBuf);
+            context.workHandler().execute(() -> this.updateLevelCube(context.level().get(), x, y, z, payload));
         }
 
         private void updateLevelCube(Level level, int x, int y, int z, CCClientboundLevelCubeWithLightPacket payload) {

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/network/CCNetworkHandler.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/network/CCNetworkHandler.java
@@ -17,7 +17,7 @@ public class CCNetworkHandler {
         // Sets the current network version
         final IPayloadRegistrar registrar = event.registrar(CubicChunks.MODID);
 
-        registrar.play(CCClientboundLevelCubeWithLightPacket.ID, new CCClientboundLevelCubeWithLightPacket.Handler(), new CCClientboundLevelCubeWithLightPacket.Handler());
-        registrar.play(CCClientboundLevelChunkPacket.ID, new CCClientboundLevelChunkPacket.Handler(), new CCClientboundLevelChunkPacket.Handler());
+        registrar.play(CCClientboundLevelCubeWithLightPacket.ID, CCClientboundLevelCubeWithLightPacket::new, new CCClientboundLevelCubeWithLightPacket.Handler());
+        registrar.play(CCClientboundLevelChunkPacket.ID, CCClientboundLevelChunkPacket::new, new CCClientboundLevelChunkPacket.Handler());
     }
 }

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/test/network/TestCCClientboundLevelCubeWithLightPacket.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/test/network/TestCCClientboundLevelCubeWithLightPacket.java
@@ -19,6 +19,7 @@ import io.github.opencubicchunks.cubicchunks.client.multiplayer.ClientCubeCache;
 import io.github.opencubicchunks.cubicchunks.network.CCClientboundLevelChunkPacket;
 import io.github.opencubicchunks.cubicchunks.network.CCClientboundLevelCubeWithLightPacket;
 import io.github.opencubicchunks.cubicchunks.testutils.BaseTest;
+import io.github.opencubicchunks.cubicchunks.testutils.Misc;
 import io.github.opencubicchunks.cubicchunks.world.level.cube.LevelCube;
 import io.netty.buffer.Unpooled;
 import net.minecraft.client.multiplayer.ClientChunkCache;
@@ -67,6 +68,8 @@ public class TestCCClientboundLevelCubeWithLightPacket extends BaseTest {
         when(clientLevelMock.getSectionsCount()).thenReturn(24);
 
         when(payloadContextMock.level()).thenReturn(Optional.of(clientLevelMock));
+
+        when(payloadContextMock.workHandler()).thenReturn(new Misc.DummyWorkHandler());
 
         var pos = CubePos.of(10, -2, 4);
         var cube = generateRandomLevelCube(clientLevelMock, pos, new Random(3333));

--- a/src/test/java/io/github/opencubicchunks/cubicchunks/testutils/Misc.java
+++ b/src/test/java/io/github/opencubicchunks/cubicchunks/testutils/Misc.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.withSettings;
 import java.nio.file.Files;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -26,6 +27,7 @@ import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.storage.LevelStorageSource;
+import net.neoforged.neoforge.network.handling.ISynchronizedWorkHandler;
 import org.mockito.Answers;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -96,5 +98,20 @@ public class Misc {
             .usingRecursiveComparison()
             .usingOverriddenEquals()
             .isEqualTo(expected);
+    }
+
+    public static class DummyWorkHandler implements ISynchronizedWorkHandler {
+        @Override public void execute(Runnable task) {
+            task.run();
+        }
+
+        @Override public CompletableFuture<Void> submitAsync(Runnable task) {
+            task.run();
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override public <T> CompletableFuture<T> submitAsync(Supplier<T> task) {
+            return CompletableFuture.completedFuture(task.get());
+        }
     }
 }


### PR DESCRIPTION
Also remove FriendlyByteBuf.Reader impl; we can just pass in ::new of the packet itself when registering