### PR TITLE
Dasm 2.5.4 + Logging colours

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ dependencies {
         targetConfiguration = "testArchivesOutput"
     }
 
-    libraries("io.github.notstirred:dasm:2.5.2") {
+    libraries("io.github.notstirred:dasm:2.5.4") {
         transitive = false
     }
     libraries("io.github.opencubicchunks:regionlib:0.63.0-SNAPSHOT")

--- a/build.gradle
+++ b/build.gradle
@@ -190,6 +190,7 @@ neoForge {
             jvmArguments = args
             // systemProperty 'forge.logging.markers', 'REGISTRIES'
             systemProperty 'forge.logging.console.level', 'debug'
+            systemProperty 'terminal.ansi', 'true'
         }
 
         client {

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,9 @@ neoForge {
         configureEach {
             jvmArguments = args
             // systemProperty 'forge.logging.markers', 'REGISTRIES'
-            systemProperty 'forge.logging.console.level', 'debug'
+            systemProperty 'forge.logging.console.level', 'info'
+            logLevel = org.slf4j.event.Level.INFO
+
             systemProperty 'terminal.ansi', 'true'
         }
 

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
@@ -88,6 +88,7 @@ public class ASMConfigPlugin implements IMixinConfigPlugin {
         return null;
     }
 
+    @SuppressWarnings("checkstyle:CyclomaticComplexity") // I'm to lazy to fix this as the class is hopefully being deleted soon
     @Override public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         try {
             ClassNode targetClass = MixinService.getService().getBytecodeProvider().getClassNode(targetClassName);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
@@ -301,7 +301,7 @@ public class ASMConfigPlugin implements IMixinConfigPlugin {
                     logger.warn(notification.message);
                     break;
                 case ERROR:
-                    logger.error(notification.message);
+                    logger.fatal(notification.message);
                     break;
                 default:
                     throw new IllegalStateException("Unknown enum variant: " + notification.kind);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
@@ -87,7 +87,6 @@ public class ASMConfigPlugin implements IMixinConfigPlugin {
         try {
             ClassNode targetClass = MixinService.getService().getBytecodeProvider().getClassNode(targetClassName);
             ClassNode mixinClass = MixinService.getService().getBytecodeProvider().getClassNode(mixinClassName);
-            mixinClass.name = targetClass.name;
 
             // PRE_APPLY
             handleError(this.annotationParser.findDasmAnnotations(mixinClass));

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/ASMConfigPlugin.java
@@ -22,6 +22,9 @@ import javax.annotation.Nullable;
 
 import com.mojang.datafixers.util.Either;
 import io.github.notstirred.dasm.annotation.AnnotationParser;
+import io.github.notstirred.dasm.annotation.AnnotationUtil;
+import io.github.notstirred.dasm.annotation.parse.RefImpl;
+import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.transform.ApplicationStage;
 import io.github.notstirred.dasm.api.provider.MappingsProvider;
 import io.github.notstirred.dasm.exception.DasmException;
@@ -30,6 +33,7 @@ import io.github.notstirred.dasm.transformer.Transformer;
 import io.github.notstirred.dasm.transformer.data.ClassTransform;
 import io.github.notstirred.dasm.transformer.data.MethodTransform;
 import io.github.notstirred.dasm.util.CachingClassProvider;
+import io.github.notstirred.dasm.util.Format;
 import io.github.notstirred.dasm.util.NotifyStack;
 import io.github.notstirred.dasm.util.Pair;
 import io.github.opencubicchunks.cc_core.annotation.Public;
@@ -39,6 +43,7 @@ import net.neoforged.fml.loading.FMLEnvironment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -87,6 +92,17 @@ public class ASMConfigPlugin implements IMixinConfigPlugin {
         try {
             ClassNode targetClass = MixinService.getService().getBytecodeProvider().getClassNode(targetClassName);
             ClassNode mixinClass = MixinService.getService().getBytecodeProvider().getClassNode(mixinClassName);
+
+            // Helpfully crash if dasm target doesn't make sense for a mixin class. This uses a ton of mostly static dasm internals.
+            AnnotationNode dasmAnnotation = AnnotationUtil.getAnnotationIfPresent(mixinClass.invisibleAnnotations, Dasm.class);
+            if (dasmAnnotation != null) {
+                Optional<Type> dasmTarget = RefImpl
+                        .parseOptionalRefAnnotation((AnnotationNode) AnnotationUtil.getAnnotationValues(dasmAnnotation, Dasm.class).get("target"));
+                if (dasmTarget.isEmpty() || dasmTarget.get().equals(Type.getType(Dasm.SELF_TARGET.class))) {
+                    throw new RuntimeException("Mixin class " + Format.formatObjectType(Type.getObjectType(mixinClass.name))
+                            + " with @Dasm annotation should probably have a @Dasm(value = Set.class, target = ...) targeting the mixin target class");
+                }
+            }
 
             // PRE_APPLY
             handleError(this.annotationParser.findDasmAnnotations(mixinClass));

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/multiplayer/MixinClientChunkCache.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/multiplayer/MixinClientChunkCache.java
@@ -41,7 +41,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  * center and range of the chunk storage.
  * This mixin adds versions of these methods for cubes, meaning that this class now stores both cubes and chunks.
  */
-@Dasm(ChunkToCubeSet.class)
+@Dasm(value = ChunkToCubeSet.class, target = @Ref(ClientChunkCache.class))
 @Mixin(ClientChunkCache.class)
 public abstract class MixinClientChunkCache extends MixinChunkSource implements ClientCubeCache {
     @AddFieldToSets(containers = ChunkToCubeSet.ClientChunkCache_redirects.class, field = @FieldSig(type = @Ref(ClientChunkCache.Storage.class), name = "storage"))

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/renderer/MixinLevelRenderer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/renderer/MixinLevelRenderer.java
@@ -3,6 +3,7 @@ package io.github.opencubicchunks.cubicchunks.mixin.core.client.renderer;
 import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cc_core.api.CubePos;
 import io.github.opencubicchunks.cubicchunks.client.renderer.CubicLevelRenderer;
@@ -10,7 +11,7 @@ import io.github.opencubicchunks.cubicchunks.mixin.dasmsets.ChunkToCubeSet;
 import net.minecraft.client.renderer.LevelRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Dasm(ChunkToCubeSet.class)
+@Dasm(value = ChunkToCubeSet.class, target = @Ref(LevelRenderer.class))
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer implements CubicLevelRenderer {
     @AddTransformToSets(ChunkToCubeSet.LevelRenderer_redirects.class)

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/renderer/MixinSectionOcclusionGraph.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/client/renderer/MixinSectionOcclusionGraph.java
@@ -8,6 +8,7 @@ import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddMethodToSets;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cc_core.api.CubePos;
 import io.github.opencubicchunks.cc_core.utils.Coords;
@@ -28,7 +29,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Dasm(ChunkToCubeSet.class)
+@Dasm(value = ChunkToCubeSet.class, target = @Ref(SectionOcclusionGraph.class))
 @Mixin(SectionOcclusionGraph.class)
 public abstract class MixinSectionOcclusionGraph {
     private boolean cc_isCubic = false;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/movetoforgesourcesetlater/MixinGenerationChunkHolder_Forge.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/movetoforgesourcesetlater/MixinGenerationChunkHolder_Forge.java
@@ -14,7 +14,7 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
-@Dasm(GlobalSet.class)
+@Dasm(value = GlobalSet.class, target = @Ref(GenerationChunkHolder.class))
 @Mixin(GenerationChunkHolder.class)
 public class MixinGenerationChunkHolder_Forge {
     protected CubePos cc_cubePos;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkGenerationTask.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkGenerationTask.java
@@ -48,7 +48,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * invariants
  * (cube status never exceeds the status of any chunks intersecting it)
  */
-@Dasm(GlobalSet.class)
+@Dasm(value = GlobalSet.class, target = @Ref(ChunkGenerationTask.class))
 @Mixin(ChunkGenerationTask.class)
 public abstract class MixinChunkGenerationTask implements CloGenerationTask {
     @Shadow @Final private ChunkPos pos;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkHolder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkHolder.java
@@ -51,7 +51,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * This mixin adds cubic chunks equivalents for methods where necessary, to allow GenerationChunkHolder to dynamically wrap either a chunk or a cube
  * (i.e. a CLO).
  */
-@Dasm(ChunkToCubeSet.class)
+@Dasm(value = ChunkToCubeSet.class, target = @Ref(ChunkHolder.class))
 @Mixin(ChunkHolder.class)
 public abstract class MixinChunkHolder extends MixinGenerationChunkHolder implements CloHolder, CubeHolder {
     @Shadow private boolean hasChangedSections;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkMap$TrackedEntity.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkMap$TrackedEntity.java
@@ -3,6 +3,7 @@ package io.github.opencubicchunks.cubicchunks.mixin.core.common.server.level;
 import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cubicchunks.mixin.dasmsets.ChunkToCloSet;
 import net.minecraft.server.level.ChunkMap;
@@ -15,7 +16,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ChunkMap.TrackedEntity.class))
 @Mixin(ChunkMap.TrackedEntity.class)
 public abstract class MixinChunkMap$TrackedEntity {
     @Shadow @Final Entity entity;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkMap.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkMap.java
@@ -95,7 +95,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * neighboring chunks.
  * This mixin adds cubic chunks equivalents for methods where necessary, to allow ChunkMap to work with CLOs (i.e. both chunks and cubes).
  */
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ChunkMap.class))
 @Mixin(ChunkMap.class)
 public abstract class MixinChunkMap extends MixinChunkStorage implements GeneratingCubeMap, CubicChunkMap, CubeHolder.PlayerProvider {
     @Shadow public abstract ReportedException debugFuturesAndCreateReportedException(IllegalStateException exception, String details);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkTaskDispatcher.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkTaskDispatcher.java
@@ -16,7 +16,7 @@ import io.github.opencubicchunks.cubicchunks.server.level.CubeHolder;
 import net.minecraft.server.level.ChunkTaskDispatcher;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ChunkTaskDispatcher.class))
 @Mixin(ChunkTaskDispatcher.class)
 public class MixinChunkTaskDispatcher implements CubeHolder.LevelChangeListener, CloTaskDispatcher {
     @AddTransformToSets(ChunkToCloSet.ChunkTaskDispatcher_redirects.class)

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkTaskPriorityQueue.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinChunkTaskPriorityQueue.java
@@ -3,6 +3,7 @@ package io.github.opencubicchunks.cubicchunks.mixin.core.common.server.level;
 import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cc_core.annotation.UsedFromASM;
 import io.github.opencubicchunks.cc_core.world.level.CloPos;
@@ -15,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ChunkTaskPriorityQueue.class))
 @Mixin(ChunkTaskPriorityQueue.class)
 public abstract class MixinChunkTaskPriorityQueue implements MarkableAsCubic {
     protected boolean cc_isCubic;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinDistanceManager.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinDistanceManager.java
@@ -4,6 +4,7 @@ import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import io.github.notstirred.dasm.api.annotations.Dasm;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.opencubicchunks.cc_core.world.level.CloPos;
 import io.github.opencubicchunks.cubicchunks.MarkableAsCubic;
 import io.github.opencubicchunks.cubicchunks.mixin.dasmsets.ChunkToCloSet;
@@ -29,7 +30,7 @@ import org.spongepowered.asm.mixin.injection.At;
  * <br>
  * This mixin mostly just replaces calls to ChunkPos with CloPos.
  */
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(DistanceManager.class))
 @Mixin(DistanceManager.class)
 public abstract class MixinDistanceManager implements MarkableAsCubic {
     protected boolean cc_isCubic;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinGenerationChunkHolder.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinGenerationChunkHolder.java
@@ -49,7 +49,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * This mixin adds cubic chunks equivalents for methods where necessary, to allow GenerationChunkHolder to dynamically wrap either a chunk or a cube
  * (i.e. a CLO).
  */
-@Dasm(ChunkToCubeSet.class)
+@Dasm(value = ChunkToCubeSet.class, target = @Ref(GenerationChunkHolder.class))
 @Mixin(GenerationChunkHolder.class)
 public abstract class MixinGenerationChunkHolder implements GenerationCloHolder {
     @Shadow @Final protected ChunkPos pos;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinServerChunkCache.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinServerChunkCache.java
@@ -71,7 +71,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * block+light updates, managing chunkloading tickets, etc.
  * This mixin adds versions of these methods for cubes, meaning that this class now stores and manages both cubes and chunks.
  */
-@Dasm(ChunkToCubeSet.class)
+@Dasm(value = ChunkToCubeSet.class, target = @Ref(ServerChunkCache.class))
 @Mixin(ServerChunkCache.class)
 public abstract class MixinServerChunkCache extends MixinChunkSource implements ServerCubeCache {
     // Cube equivalents for cached chunks

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinServerLevel.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinServerLevel.java
@@ -9,6 +9,7 @@ import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddMethodToSets;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cc_core.world.level.CloPos;
 import io.github.opencubicchunks.cubicchunks.mixin.core.common.world.level.MixinLevel;
@@ -37,7 +38,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ServerLevel.class))
 @Mixin(ServerLevel.class)
 public abstract class MixinServerLevel extends MixinLevel implements CubicServerLevel {
     @Shadow @Final private ServerChunkCache chunkSource;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinServerPlayer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinServerPlayer.java
@@ -15,7 +15,7 @@ import net.minecraft.server.level.ChunkTrackingView;
 import net.minecraft.server.level.ServerPlayer;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ServerPlayer.class))
 @Mixin(ServerPlayer.class)
 public abstract class MixinServerPlayer extends MixinEntity implements CCServerPlayer {
     @AddFieldToSets(containers = ChunkToCloSet.ServerPlayer_redirects.class, field = @FieldSig(type = @Ref(ChunkTrackingView.class), name = "chunkTrackingView"))

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinSimulationChunkTracker.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/MixinSimulationChunkTracker.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(SimulationChunkTracker.class))
 @Mixin(SimulationChunkTracker.class)
 public abstract class MixinSimulationChunkTracker extends MixinChunkTracker implements SimulationCloTracker {
     @AddTransformToSets(ChunkToCloSet.SimulationChunkTracker_redirects.class)

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/progress/MixinLoggerChunkProgressListener.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/progress/MixinLoggerChunkProgressListener.java
@@ -3,6 +3,7 @@ package io.github.opencubicchunks.cubicchunks.mixin.core.common.server.level.pro
 import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cc_core.world.level.CloPos;
 import io.github.opencubicchunks.cubicchunks.mixin.dasmsets.ChunkToCloSet;
@@ -12,7 +13,7 @@ import net.minecraft.world.level.chunk.status.ChunkStatus;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(LoggerChunkProgressListener.class))
 @Mixin(LoggerChunkProgressListener.class)
 public abstract class MixinLoggerChunkProgressListener implements CloProgressListener {
     @AddTransformToSets(ChunkToCloSet.LoggerChunkProgressListener_redirects.class)

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/progress/MixinProcessorChunkProgressListener.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/progress/MixinProcessorChunkProgressListener.java
@@ -22,7 +22,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ProcessorChunkProgressListener.class))
 @Mixin(ProcessorChunkProgressListener.class)
 public abstract class MixinProcessorChunkProgressListener implements CloProgressListener {
     // We need a field referencing the delegate as a CloProgressListener, otherwise we end up trying to access a field of the wrong type

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/progress/MixinStoringChunkProgressListener.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/level/progress/MixinStoringChunkProgressListener.java
@@ -18,7 +18,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(StoringChunkProgressListener.class))
 @Mixin(StoringChunkProgressListener.class)
 public abstract class MixinStoringChunkProgressListener implements CloProgressListener {
     @AddFieldToSets(containers = GlobalSet.StoringChunkProgressListener_redirects.class, field = @FieldSig(type = @Ref(ChunkPos.class), name = "spawnPos"))

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/network/MixinPlayerChunkSender.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/network/MixinPlayerChunkSender.java
@@ -8,6 +8,7 @@ import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddMethodToSets;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cc_core.world.level.CloPos;
 import io.github.opencubicchunks.cubicchunks.CanBeCubic;
@@ -38,7 +39,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(PlayerChunkSender.class))
 @Mixin(PlayerChunkSender.class)
 public class MixinPlayerChunkSender {
     @Shadow private int unacknowledgedBatches;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/entity/MixinEntity.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/entity/MixinEntity.java
@@ -34,7 +34,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  * We modify Entity to track its cube position, and to replace calls to chunk-specific methods with their corresponding cubic methods when in a cubic
  * Level.
  */
-@Dasm(ChunkToCubeSet.class)
+@Dasm(value = ChunkToCubeSet.class, target = @Ref(Entity.class))
 @Mixin(Entity.class)
 public abstract class MixinEntity implements EntityCubePosGetter {
     @Shadow private Level level;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/level/MixinLevel.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/level/MixinLevel.java
@@ -11,6 +11,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddTransformToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.notstirred.dasm.api.annotations.transform.TransformFromMethod;
 import io.github.opencubicchunks.cc_core.utils.Coords;
 import io.github.opencubicchunks.cubicchunks.CubicChunks;
@@ -42,7 +43,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(Level.class))
 @Mixin(Level.class)
 public abstract class MixinLevel implements CubicLevel, MarkableAsCubic, LevelAccessor {
     @Shadow public abstract @Nullable ChunkAccess getChunk(int chunkX, int chunkZ, ChunkStatus requestedStatus, boolean forceLoad);

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/level/MixinTicketStorage.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/level/MixinTicketStorage.java
@@ -13,7 +13,7 @@ import net.minecraft.server.level.TicketType;
 import net.minecraft.world.level.TicketStorage;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(TicketStorage.class))
 @Mixin(TicketStorage.class)
 public class MixinTicketStorage implements CubicTicketStorage {
     // TODO (P2) codec nonsense for save/load

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/level/chunk/storage/MixinChunkStorage.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/world/level/chunk/storage/MixinChunkStorage.java
@@ -6,13 +6,14 @@ import java.util.concurrent.CompletableFuture;
 import io.github.notstirred.dasm.api.annotations.Dasm;
 import io.github.notstirred.dasm.api.annotations.redirect.redirects.AddMethodToSets;
 import io.github.notstirred.dasm.api.annotations.selector.MethodSig;
+import io.github.notstirred.dasm.api.annotations.selector.Ref;
 import io.github.opencubicchunks.cc_core.world.level.CloPos;
 import io.github.opencubicchunks.cubicchunks.mixin.dasmsets.ChunkToCloSet;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.chunk.storage.ChunkStorage;
 import org.spongepowered.asm.mixin.Mixin;
 
-@Dasm(ChunkToCloSet.class)
+@Dasm(value = ChunkToCloSet.class, target = @Ref(ChunkStorage.class))
 @Mixin(ChunkStorage.class)
 public abstract class MixinChunkStorage {
     @AddMethodToSets(containers = ChunkToCloSet.ChunkStorage_redirects.class, method = @MethodSig("isOldChunkAround(Lnet/minecraft/world/level/ChunkPos;I)Z"))


### PR DESCRIPTION
Relevant changes
- [parser: Add AddFieldToMethodToSets](https://github.com/NotStirred/dasm/commit/af6e2f79f0e0b9c9ec487574265dc99eff0b0408)
- [transformer: Fix static FieldToMethodRedirects generating wrong INVOKE instruction](https://github.com/NotStirred/dasm/commit/a78fd74e29852bfb860926a53b05f784a17c08ff)
- Dasm `TypeRemapper` logs are now `TRACE`, so there is almost no dasm log spam anymore.