### PR TITLE
Add per-tick async profiler modes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,13 @@ mixinGen {
         it.injectorsDefaultRequire = 1
     }
 
+    config(sourceSets.main, "debug") {
+        it.required = false
+        it.conformVisibility = true
+        it.injectorsDefaultRequire = 0
+        it.configurationPlugin = "io.github.opencubicchunks.cubicchunks.mixin.DebugMixinConfig"
+    }
+
     config(sourceSets.forge, "forge") {
         it.required = true
         it.conformVisibility = true
@@ -129,13 +136,6 @@ mixinGen {
         injectorsDefaultRequire = 1
     }
 
-    config("debug") {
-        required = false
-        conformVisibility = true
-        injectorsDefaultRequire = 0
-        configurationPlugin = "io.github.opencubicchunks.cubicchunks.mixin.DebugMixinConfig"
-    }
-
     config("test") {
         required = true
         conformVisibility = true
@@ -173,16 +173,8 @@ neoForge {
                 "-Dmixin.debug.export=true",
                 "-Dmixin.checks.interfaces=true",
                 "-Dcubicchunks.debug=false",
-                "-Dcubicchunks.debug.loadorder=false",
-                "-Dcubicchunks.debug.window=false",
-                "-Dcubicchunks.debug.statusrenderer=false",
-                "-Dcubicchunks.debug.heightmaprenderer=false",
-                "-Dcubicchunks.debug.heightmaprenderer.server=false",
-                "-Dcubicchunks.debug.heightmaprenderer.render_lightmap=false",
-                "-Dcubicchunks.debug.heightmaprenderer.radius=2",
-                "-Dcubicchunks.debug.heightmapverification=false",
-                "-Dcubicchunks.debug.heightmapverification.frequency=1",
-                "-Dcubicchunks.debug.biomes=false",
+                "-Dcubicchunks.debug.profiler=false",
+                "-Dcubicchunks.debug.profiler.interval_ns=1",
                 "-ea"
         ]
         // applies to all the run configs below
@@ -272,6 +264,8 @@ dependencies {
     }
     libraries("io.github.opencubicchunks:regionlib:0.63.0-SNAPSHOT")
     libraries("org.spongepowered:noise:2.0.0-SNAPSHOT")
+
+    libraries('tools.profiler:async-profiler:4.0')
 
     testImplementation("org.assertj:assertj-core:3.25.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")

--- a/buildSrc/src/main/java/io/github/opencubicchunks/gradle/FixAnnotationsFormatterStep.java
+++ b/buildSrc/src/main/java/io/github/opencubicchunks/gradle/FixAnnotationsFormatterStep.java
@@ -12,7 +12,7 @@ public class FixAnnotationsFormatterStep implements FormatterStep {
     }
 
     private static final String[] ANNOTATIONS = { "@Shadow", "@Final", "@Mutable", "@Public", "@Override", "@Nullable", "@NotNull", "@Invoker",
-        "@Accessor", "@Dynamic" };
+        "@Accessor", "@Dynamic", "@Unique" };
 
     @Override public @Nullable String format(String s, @NotNull File file) {
         var outputString = s;

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/DebugMixinConfig.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/DebugMixinConfig.java
@@ -1,0 +1,32 @@
+package io.github.opencubicchunks.cubicchunks.mixin;
+
+import java.util.List;
+import java.util.Set;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+public class DebugMixinConfig implements IMixinConfigPlugin {
+    private static final boolean DEBUG_MIXINS_ENABLED = System.getProperty("cubicchunks.debug", "false").equals("true");
+
+    @Override public void onLoad(String mixinPackage) {}
+
+    @Override public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return DEBUG_MIXINS_ENABLED;
+    }
+
+    @Override public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override public List<String> getMixins() {
+        return null;
+    }
+
+    @Override public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    @Override public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/network/MixinPlayerChunkSender.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/core/common/server/network/MixinPlayerChunkSender.java
@@ -112,8 +112,7 @@ public class MixinPlayerChunkSender {
         }
     }
 
-    @Unique
-    private static void cc_sendCube(ServerGamePacketListenerImpl packetListener, ServerLevel level, LevelCube cube) {
+    @Unique private static void cc_sendCube(ServerGamePacketListenerImpl packetListener, ServerLevel level, LevelCube cube) {
         PacketDistributor.sendToPlayer(packetListener.player, new CCClientboundLevelCubeWithLightPacket(cube));
 
         // ChunkPos chunkpos = chunk.getPos();
@@ -125,8 +124,7 @@ public class MixinPlayerChunkSender {
         // net.neoforged.neoforge.event.EventHooks.fireChunkSent(packetListener.player, chunk, level);
     }
 
-    @Unique
-    private static void cc_sendChunk(ServerGamePacketListenerImpl packetListener, ServerLevel level, LevelChunk chunk) {
+    @Unique private static void cc_sendChunk(ServerGamePacketListenerImpl packetListener, ServerLevel level, LevelChunk chunk) {
         PacketDistributor.sendToPlayer(packetListener.player, new CCClientboundLevelChunkPacket(chunk.getPos()));
 
         // ChunkPos chunkpos = chunk.getPos();

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/MixinMinecraftServer.java
@@ -1,0 +1,86 @@
+package io.github.opencubicchunks.cubicchunks.mixin.debug.common;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+
+import io.github.opencubicchunks.cubicchunks.CubicChunks;
+import net.minecraft.server.MinecraftServer;
+import one.profiler.AsyncProfiler;
+import org.apache.commons.io.FileUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+    @Unique private static final boolean perf_doProfiling = System.getProperty("cubicchunks.debug.profiler", "false").equals("true");
+
+    @Unique private static final Path perf_basePath = Path.of(System.getProperty("cubicchunks.debug.profiler.path", "profiler"));
+    @Unique private static final int perf_interval = Integer.parseInt(System.getProperty("cubicchunks.debug.profiler.interval_ns", "1"));
+
+    @Unique private static final AsyncProfiler perf_PROFILER = AsyncProfiler.getInstance();
+    @Unique private static boolean perf_started = false;
+    @Unique private static int perf_idx = 0;
+
+    @Unique private static long perf_tickStartTime = 0;
+
+    static {
+        try {
+            FileUtils.deleteDirectory(perf_basePath.toFile());
+        } catch (IOException e) {
+            CubicChunks.LOGGER.error("[tick-profiler] Failed to clear existing output directory {}", perf_basePath, e);
+        }
+    }
+
+    @Inject(method = "tickServer", at = @At("HEAD"))
+    private void onTick(BooleanSupplier hasTimeLeft, CallbackInfo ci) {
+        if (!perf_doProfiling) {
+            return;
+        }
+
+        perf_stopProfiler();
+
+        // Start a new profiler
+        Path path = perf_basePath.resolve(perf_idx++ + ".jfr").toAbsolutePath();
+        try {
+            Files.createDirectories(path.getParent());
+            perf_PROFILER.execute("start,jfr,interval=" + perf_interval + ",event=cpu,file=" + path.toAbsolutePath());
+        } catch (IOException e) {
+            CubicChunks.LOGGER.error("[tick-profiler] Failed to start async-profiler", e);
+        }
+        perf_started = true;
+        perf_tickStartTime = System.nanoTime();
+    }
+
+    @Inject(method = "stopServer", at = @At("HEAD"))
+    private void onStop(CallbackInfo ci) {
+        perf_stopProfiler();
+    }
+
+    @Unique private static void perf_stopProfiler() {
+        if (perf_started) {
+            // Stop the currently running profiler
+            try {
+                perf_PROFILER.execute("stop");
+            } catch (IOException e) {
+                CubicChunks.LOGGER.error("[tick-profiler] Failed to stop async-profiler", e);
+            }
+            perf_started = false;
+
+            // Rename the just stopped profiler output file to include its duration for easy sorting
+            int previousIndex = perf_idx - 1;
+            Duration duration = Duration.ofNanos(System.nanoTime() - perf_tickStartTime);
+            try {
+                Files.move(perf_basePath.resolve(previousIndex + ".jfr"), perf_basePath.resolve(duration.toMillis() + "_" + previousIndex + ".jfr"));
+            } catch (IOException e) {
+                CubicChunks.LOGGER.error("[tick-profiler] Failed to rename jfr file to include tick duration", e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/package-info.java
+++ b/src/main/java/io/github/opencubicchunks/cubicchunks/mixin/debug/common/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package io.github.opencubicchunks.cubicchunks.mixin.debug.common;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.github.opencubicchunks.cc_core.annotation.MethodsReturnNonnullByDefault;

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -77,3 +77,6 @@ config="${mod_id}.mixins.core.json"
 
 [[mixins]]
 config="${mod_id}.mixins.access.json"
+
+[[mixins]]
+config="${mod_id}.mixins.debug.json"


### PR DESCRIPTION
The profiled sections are from the start of one tick until the start of the next; is this the best approach? Not really sure.

To test enable both the `cubicchunks.debug` and `cubicchunks.debug.profiler` jvm options
Output is in the `profiler` directory of the run location.

File format is `durationOfTickInMillis_tickIdx.jfr` for easy sorting.